### PR TITLE
Bump version only

### DIFF
--- a/.github/workflows/build_rpms.yml
+++ b/.github/workflows/build_rpms.yml
@@ -38,11 +38,9 @@ jobs:
         run: |
           docker run -v ${PWD}:/sources -v ${PWD}:/output:Z quay.io/abn/rpmbuilder:centos-7
       - name: Build the srpm package from ${{ matrix.packages }}
-        env:
-          SRPM_ONLY:  1
         working-directory: ${{ matrix.packages }}
         run: |
-          docker run -v ${PWD}:/sources -v ${PWD}:/output:Z quay.io/abn/rpmbuilder:centos-7
+          docker run -v ${PWD}:/sources -v ${PWD}:/output:Z -e "SRPM_ONLY=1" quay.io/abn/rpmbuilder:centos-7
       - name: Install API token for copr-cli
         env:
           API_LOGIN_CONTENT: ${{ secrets.COPR_API_LOGIN }}

--- a/SOURCES/hypervm-core-php/hypervm-core-php.spec
+++ b/SOURCES/hypervm-core-php/hypervm-core-php.spec
@@ -1,7 +1,7 @@
 %define name 	hypervm-core-php
 %define packagename php
 %define version 5.4.16
-%define release 9%{?dist}
+%define release 10%{?dist}
 %define brand   lxlabs
 
 %if 0%{?fedora} < 17 && 0%{?rhel} < 7
@@ -567,6 +567,9 @@ rm -rf %{buildroot}
 %doc
 
 %changelog
+* Sat Mar 13 2021 Krzysztof Taraszka <krzysztof.taraszka@hypervm-ng.org> 5.4.16-10
+- Bump version
+
 * Wed Mar 10 2021 Krzysztof Taraszka <krzysztof.taraszka@hypervm-ng.org> 5.4.16-9
 - Added BuildRequires required by docker rpm builder
 

--- a/SOURCES/lxlighttpd/lxlighttpd.spec
+++ b/SOURCES/lxlighttpd/lxlighttpd.spec
@@ -1,7 +1,7 @@
 Summary: Webserver for LxCenter products (based on lighttpd)
 Name: lxlighttpd
 Version: 1.4.59
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: BSD
 Group: System Environment/Daemons
 URL: http://www.hypervm-ng.org
@@ -154,6 +154,9 @@ This is the Core GUI webserver for HyperVM-NG product (based on lighttpd)
 
 
 %changelog
+* Sat Mar 13 2021 Krzysztof Taraszka <krzysztof.taraszka@hypervm-ng.org> 1.4.59-3
+- Bump version
+
 * Wed Mar 3 2021 Krzysztof Taraszka <krzysztof.taraszka@hypervm-ng.org> 1.4.59-2
 - Added BuildRequires required by docker rpm builder
 

--- a/SOURCES/yum-plugin-replace/yum-plugin-replace.spec
+++ b/SOURCES/yum-plugin-replace/yum-plugin-replace.spec
@@ -1,7 +1,7 @@
 
 Name: yum-plugin-replace        
 Version:    0.2.5
-Release:    2%{?dist}
+Release:    3%{?dist}
 Summary:    Package Replacement Plugin for Yum
 
 Group:      System Environment/Base     
@@ -52,6 +52,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Sat Mar 13 2021 Krzysztof Taraszka <krzysztof.taraszka@hypervm-ng.org> 0.2.5-3
+- Bump version
+
 * Sun Oct 16 2016 Krzysztof Taraszka <krzysztof.taraszka@hypervm-ng.org> 0.2.5-2
 - Relese 2
 - Removed ius from Release


### PR DESCRIPTION
Once we merge this PR, it will trigger a Github action that will test build rpm package(s), create src.rpm files, and push them to the Copr builder as an official release (builds from the master are going to the hypervm-ng yum repo ONLY)